### PR TITLE
fix: add validation for empty AllowPorts in local port filtering

### DIFF
--- a/src/LocalPortFiltering.AspNetCore/LocalPortFilteringMiddleware.cs
+++ b/src/LocalPortFiltering.AspNetCore/LocalPortFilteringMiddleware.cs
@@ -51,6 +51,8 @@ public class LocalPortFilteringMiddleware
         if (exceptionHandler == null)
             return m_Next(context);
 
+        if (exceptionHandler.AllowPorts == null || exceptionHandler.AllowPorts.Count == 0)
+            return HostValidationFailed(context);
         if (!exceptionHandler.AllowPorts.Contains(context.Connection.LocalPort))
             return HostValidationFailed(context);
 

--- a/test/LocalPortFiltering.AspNetCore.Tests/LocalPortFilteringMiddlewareTests.cs
+++ b/test/LocalPortFiltering.AspNetCore.Tests/LocalPortFilteringMiddlewareTests.cs
@@ -43,6 +43,7 @@ public class LocalPortFilteringMiddlewareTests
 
     [Theory]
     [InlineData(200, 443, new int[] { 443 })]
+    [InlineData(403, 443, new int[] { })]
     [InlineData(403, 80, new int[] { 443 })]
     [InlineData(200, 3000, new int[] { 3000, 3001 })]
     [InlineData(403, 4000, new int[] { 3000, 3001 })]


### PR DESCRIPTION
- Added a check to validate if `AllowPorts` is null or empty in the local port filtering logic. If invalid, the request handling now invokes `HostValidationFailed`.