### PR TITLE
fix: add missing NuGet documentation generation

### DIFF
--- a/src/LocalPortFiltering.AspNetCore/LocalPortFiltering.AspNetCore.csproj
+++ b/src/LocalPortFiltering.AspNetCore/LocalPortFiltering.AspNetCore.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RootNamespace>LocalPortFiltering.AspNetCore</RootNamespace>
 
     <!-- NuGet Packaging -->

--- a/src/LocalPortFiltering.AspNetCore/LocalPortFilteringOptions.cs
+++ b/src/LocalPortFiltering.AspNetCore/LocalPortFilteringOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace LocalPortFiltering.AspNetCore;
 
+/// <summary>
+/// Represents the options for local port filtering configuration in the ASP.NET Core application.
+/// </summary>
 public class LocalPortFilteringOptions
 {
     /// <summary>


### PR DESCRIPTION
This pull request addresses an issue with the NuGet package where the documentation generation was not enabled. 

### Changes:
- Added the `<GenerateDocumentationFile>true</GenerateDocumentationFile>` setting to ensure that the documentation file is generated during the build process.

This change will ensure that the generated NuGet package includes the necessary documentation file for consumers.
