### PR TITLE
test: add dynamic option update handling in LocalPortFilteringMiddlew…

### DIFF
--- a/test/LocalPortFiltering.AspNetCore.Tests/LocalPortFiltering.AspNetCore.Tests.csproj
+++ b/test/LocalPortFiltering.AspNetCore.Tests/LocalPortFiltering.AspNetCore.Tests.csproj
@@ -14,6 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.11" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
### Summary

- Added tests to verify dynamic option updates in `LocalPortFilteringMiddleware`.
- Mocked `IOptionsMonitor` to simulate `OnChange` behavior for configuration changes.
- Included `InlineData` to test different initial and updated configurations for `IncludeFailureMessage`.

### Changes

1. Enhanced test coverage for dynamic configuration updates.
2. Verified middleware responses for:
   - Initial configuration values.
   - Updated configuration values triggered by `OnChange`.

